### PR TITLE
fix: update moduleResolution for Storybook v10 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- Update `moduleResolution` from `node` to `bundler` in tsconfig.json
- Fixes TypeScript type resolution for Storybook v10 packages

## Test plan
- [ ] Type check passes
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)